### PR TITLE
[SPRINT] Apr 4 2019 → Apr 8 2019 - Release version 1.0

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,10 +1,11 @@
-# How to contribute to maoctrl
+# How to contribute to mao-client
 ## Reporting issue
-When reporting issue please include as much detail as possible about your operating system, `mao-ctrl` version and `Go` version. Whenever possible, please also include a brief, self-contained code example that demonstrates the problem.
+When reporting issue please include as much detail as possible about your operating system, `mao-client` version and `Go` version.
+Whenever possible, please also include a brief, self-contained code example that demonstrates the problem.
 
 
 ## Contributing code
-Thanks for your interest in contributing code to `mao-ctrl`!
+Thanks for your interest in contributing code to `mao-client`!
 
 When sending pull request please write as much detail as possible.
 

--- a/adapters/controller/wfs.go
+++ b/adapters/controller/wfs.go
@@ -1,9 +1,9 @@
 package controller
 
 import (
-	"github.com/mao-wfs/mao-ctrl/adapters/gateway/device"
-	"github.com/mao-wfs/mao-ctrl/usecases/input"
-	"github.com/mao-wfs/mao-ctrl/usecases/interactor"
+	"github.com/mao-wfs/mao-client/adapters/gateway/device"
+	"github.com/mao-wfs/mao-client/usecases/input"
+	"github.com/mao-wfs/mao-client/usecases/interactor"
 )
 
 // WFSController is the controller of MAO-WFS.

--- a/adapters/gateway/device/correlator.go
+++ b/adapters/gateway/device/correlator.go
@@ -58,7 +58,11 @@ func (h *CorrelatorHandler) Finalize() error {
 }
 
 // Start starts the correlator of MAO-WFS.
+// This is the external method.
 func (h *CorrelatorHandler) Start(t domain.SensingTime) error {
+	if err := h.start(); err != nil {
+		return xerrors.Errorf("error in Start(): %w", err)
+	}
 	return nil
 }
 
@@ -81,6 +85,15 @@ func (h *CorrelatorHandler) initialize() error {
 // This is the internal method.
 func (h *CorrelatorHandler) finalize() error {
 	if err := h.reset(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// start starts the correlator of MAO-WFS.
+// This is the internal method.
+func (h *CorrelatorHandler) start() error {
+	if err := h.startCorrelation(); err != nil {
 		return err
 	}
 	return nil
@@ -124,6 +137,20 @@ func (h *CorrelatorHandler) getResultCode(msg string) int {
 // reset resets the correlator.
 func (h *CorrelatorHandler) reset() error {
 	msg := "reset=system;"
+	buf, err := h.Query(msg, defaultBufSize)
+	if err != nil {
+		return err
+	}
+	res := string(buf)
+	if err := h.checkResult(res); err != nil {
+		return err
+	}
+	return nil
+}
+
+// startCorrelation starts the correlation.
+func (h *CorrelatorHandler) startCorrelation() error {
+	msg := "ctl_corstart=2002001010000:0x10;"
 	buf, err := h.Query(msg, defaultBufSize)
 	if err != nil {
 		return err

--- a/adapters/gateway/device/correlator.go
+++ b/adapters/gateway/device/correlator.go
@@ -150,41 +150,17 @@ func (h *CorrelatorHandler) execCmd(msg string) error {
 // reset resets the correlator.
 func (h *CorrelatorHandler) reset() error {
 	msg := "reset=system;"
-	buf, err := h.Query(msg, defaultBufSize)
-	if err != nil {
-		return err
-	}
-	res := string(buf)
-	if err := h.checkResult(res); err != nil {
-		return err
-	}
-	return nil
+	return h.execCmd(msg)
 }
 
 // startCorrelation starts the correlation.
 func (h *CorrelatorHandler) startCorrelation() error {
 	msg := "ctl_corstart=2002001010000:0x10;"
-	buf, err := h.Query(msg, defaultBufSize)
-	if err != nil {
-		return err
-	}
-	res := string(buf)
-	if err := h.checkResult(res); err != nil {
-		return err
-	}
-	return nil
+	return h.execCmd(msg)
 }
 
 // stopCorrelation stops the correlation.
 func (h *CorrelatorHandler) stopCorrelation() error {
 	msg := "corr_stop=2002001010000;"
-	buf, err := h.Query(msg, defaultBufSize)
-	if err != nil {
-		return nil
-	}
-	res := string(buf)
-	if err := h.checkResult(res); err != nil {
-		return err
-	}
-	return nil
+	return h.execCmd(msg)
 }

--- a/adapters/gateway/device/correlator.go
+++ b/adapters/gateway/device/correlator.go
@@ -41,6 +41,7 @@ func NewCorrelatorHandler(clt Client) *CorrelatorHandler {
 }
 
 // Initialize initializes the correlator of MAO-WFS.
+// This is the external method.
 func (h *CorrelatorHandler) Initialize() error {
 	if err := h.initialize(); err != nil {
 		return xerrors.Errorf("error in Initialize(): %w", err)

--- a/adapters/gateway/device/correlator.go
+++ b/adapters/gateway/device/correlator.go
@@ -102,7 +102,7 @@ func (h *CorrelatorHandler) start() error {
 // halst halts the correlator of MAO-WFS.
 // This is the internal method.
 func (h *CorrelatorHandler) halt() error {
-	if err := h.stop(); err != nil {
+	if err := h.stopCorrelation(); err != nil {
 		return err
 	}
 	return nil
@@ -162,8 +162,8 @@ func (h *CorrelatorHandler) startCorrelation() error {
 	return nil
 }
 
-// stop stops the correlation.
-func (h *CorrelatorHandler) stop() error {
+// stopCorrelation stops the correlation.
+func (h *CorrelatorHandler) stopCorrelation() error {
 	msg := "corr_stop=2002001010000;"
 	buf, err := h.Query(msg, defaultBufSize)
 	if err != nil {

--- a/adapters/gateway/device/correlator.go
+++ b/adapters/gateway/device/correlator.go
@@ -6,7 +6,7 @@ import (
 
 	"golang.org/x/xerrors"
 
-	"github.com/mao-wfs/mao-ctrl/domain"
+	"github.com/mao-wfs/mao-client/domain"
 )
 
 // Result codes of the correlator operations.

--- a/adapters/gateway/device/correlator.go
+++ b/adapters/gateway/device/correlator.go
@@ -134,6 +134,19 @@ func (h *CorrelatorHandler) getResultCode(msg string) int {
 	return resCode
 }
 
+// execCmd execute a specified command.
+func (h *CorrelatorHandler) execCmd(msg string) error {
+	buf, err := h.Query(msg, defaultBufSize)
+	if err != nil {
+		return err
+	}
+	res := string(buf)
+	if err := h.checkResult(res); err != nil {
+		return err
+	}
+	return nil
+}
+
 // reset resets the correlator.
 func (h *CorrelatorHandler) reset() error {
 	msg := "reset=system;"

--- a/adapters/gateway/device/correlator.go
+++ b/adapters/gateway/device/correlator.go
@@ -130,7 +130,7 @@ func (h *CorrelatorHandler) reset() error {
 	}
 	res := string(buf)
 	if err := h.checkResult(res); err != nil {
-		return xerrors.Errorf("error in Halt(): %w", err)
+		return err
 	}
 	return nil
 }

--- a/adapters/gateway/device/correlator.go
+++ b/adapters/gateway/device/correlator.go
@@ -46,14 +46,9 @@ func (h *CorrelatorHandler) Initialize() error {
 }
 
 // Finalize finalizes the correlator of MAO-WFS.
+// This is the external method.
 func (h *CorrelatorHandler) Finalize() error {
-	msg := "reset=system;"
-	buf, err := h.Query(msg, defaultBufSize)
-	if err != nil {
-		return xerrors.Errorf("error in Finalize(): %w", err)
-	}
-	res := string(buf)
-	if err := h.checkResult(res); err != nil {
+	if err := h.finalize(); err != nil {
 		return xerrors.Errorf("error in Finalize(): %w", err)
 	}
 	return nil
@@ -74,6 +69,15 @@ func (h *CorrelatorHandler) Halt() error {
 	res := string(buf)
 	if err := h.checkResult(res); err != nil {
 		return xerrors.Errorf("error in Halt(): %w", err)
+	}
+	return nil
+}
+
+// finalize finalizes the correlator of MAO-WFS.
+// This is the internal method.
+func (h *CorrelatorHandler) finalize() error {
+	if err := h.reset(); err != nil {
+		return err
 	}
 	return nil
 }
@@ -102,4 +106,18 @@ func (h *CorrelatorHandler) getResultCode(msg string) int {
 	re := regexp.MustCompile(`[0-9]`)
 	resCode, _ := strconv.Atoi(re.FindString(msg))
 	return resCode
+}
+
+// reset resets the correlator.
+func (h *CorrelatorHandler) reset() error {
+	msg := "reset=system;"
+	buf, err := h.Query(msg, defaultBufSize)
+	if err != nil {
+		return err
+	}
+	res := string(buf)
+	if err := h.checkResult(res); err != nil {
+		return xerrors.Errorf("error in Halt(): %w", err)
+	}
+	return nil
 }

--- a/adapters/gateway/device/correlator.go
+++ b/adapters/gateway/device/correlator.go
@@ -42,6 +42,9 @@ func NewCorrelatorHandler(clt Client) *CorrelatorHandler {
 
 // Initialize initializes the correlator of MAO-WFS.
 func (h *CorrelatorHandler) Initialize() error {
+	if err := h.initialize(); err != nil {
+		return xerrors.Errorf("error in Initialize(): %w", err)
+	}
 	return nil
 }
 
@@ -70,6 +73,12 @@ func (h *CorrelatorHandler) Halt() error {
 	if err := h.checkResult(res); err != nil {
 		return xerrors.Errorf("error in Halt(): %w", err)
 	}
+	return nil
+}
+
+// initialize initializes the correlator.
+// This is the internal method.
+func (h *CorrelatorHandler) initialize() error {
 	return nil
 }
 

--- a/adapters/gateway/device/correlator.go
+++ b/adapters/gateway/device/correlator.go
@@ -63,14 +63,9 @@ func (h *CorrelatorHandler) Start(t domain.SensingTime) error {
 }
 
 // Halt halts the correlator of MAO-WFS.
+// This is the external method.
 func (h *CorrelatorHandler) Halt() error {
-	msg := "corr_stop=2002001010000;"
-	buf, err := h.Query(msg, defaultBufSize)
-	if err != nil {
-		return xerrors.Errorf("error in Halt(): %w", err)
-	}
-	res := string(buf)
-	if err := h.checkResult(res); err != nil {
+	if err := h.halt(); err != nil {
 		return xerrors.Errorf("error in Halt(): %w", err)
 	}
 	return nil
@@ -86,6 +81,15 @@ func (h *CorrelatorHandler) initialize() error {
 // This is the internal method.
 func (h *CorrelatorHandler) finalize() error {
 	if err := h.reset(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// halst halts the correlator of MAO-WFS.
+// This is the internal method.
+func (h *CorrelatorHandler) halt() error {
+	if err := h.stop(); err != nil {
 		return err
 	}
 	return nil
@@ -127,6 +131,20 @@ func (h *CorrelatorHandler) reset() error {
 	res := string(buf)
 	if err := h.checkResult(res); err != nil {
 		return xerrors.Errorf("error in Halt(): %w", err)
+	}
+	return nil
+}
+
+// stop stops the correlation.
+func (h *CorrelatorHandler) stop() error {
+	msg := "corr_stop=2002001010000;"
+	buf, err := h.Query(msg, defaultBufSize)
+	if err != nil {
+		return nil
+	}
+	res := string(buf)
+	if err := h.checkResult(res); err != nil {
+		return err
 	}
 	return nil
 }

--- a/adapters/gateway/device/switch.go
+++ b/adapters/gateway/device/switch.go
@@ -19,6 +19,7 @@ func NewSwitchHandler(clt Client) *SwitchHandler {
 }
 
 // Initialize initializes the switch of MAO-WFS.
+// This is the external method.
 func (h *SwitchHandler) Initialize(swOrder domain.SwitchOrder) error {
 	if err := h.enableDigPatt(); err != nil {
 		return xerrors.Errorf("error in Initialize(): %w", err)
@@ -27,6 +28,7 @@ func (h *SwitchHandler) Initialize(swOrder domain.SwitchOrder) error {
 }
 
 // Finalize finalizes the switch of MAO-WFS.
+// This is the external method.
 func (h *SwitchHandler) Finalize() error {
 	if err := h.finalize(); err != nil {
 		return xerrors.Errorf("error in Finalize(): %w", err)
@@ -35,6 +37,7 @@ func (h *SwitchHandler) Finalize() error {
 }
 
 // Start starts the switch of MAO-WFS.
+// This is the external method.
 func (h *SwitchHandler) Start() error {
 	if err := h.start(); err != nil {
 		return xerrors.Errorf("error in Start(): %w", err)
@@ -43,6 +46,7 @@ func (h *SwitchHandler) Start() error {
 }
 
 // Halt halts the switch of MAO-WFS.
+// This is the external method.
 func (h *SwitchHandler) Halt() error {
 	if err := h.halt(); err != nil {
 		return xerrors.Errorf("error in Start(): %w", err)
@@ -65,6 +69,7 @@ func (h *SwitchHandler) checkResult() error {
 	return nil
 }
 
+// reset resets the switch to the factory settings.
 func (h *SwitchHandler) reset() error {
 	msg := "*RST\n"
 	if err := h.Write(msg); err != nil {
@@ -73,6 +78,7 @@ func (h *SwitchHandler) reset() error {
 	return h.checkResult()
 }
 
+// clearStatus clear the current status of the switch.
 func (h *SwitchHandler) clearStatus() error {
 	msg := "*CLS\n"
 	if err := h.Write(msg); err != nil {
@@ -81,6 +87,7 @@ func (h *SwitchHandler) clearStatus() error {
 	return h.checkResult()
 }
 
+// enableOutput starts to output signal.
 func (h *SwitchHandler) enableOutput() error {
 	msg := "OUTP ON\n"
 	if err := h.Write(msg); err != nil {
@@ -89,6 +96,7 @@ func (h *SwitchHandler) enableOutput() error {
 	return h.checkResult()
 }
 
+// disableOutput stops to output signal.
 func (h *SwitchHandler) disableOutput() error {
 	msg := "OUTP OFF\n"
 	if err := h.Write(msg); err != nil {
@@ -97,6 +105,8 @@ func (h *SwitchHandler) disableOutput() error {
 	return nil
 }
 
+// finalize finalizes the switch of MAO-WFS.
+// This is the internal method.
 func (h *SwitchHandler) finalize() error {
 	if err := h.reset(); err != nil {
 		return err
@@ -107,6 +117,8 @@ func (h *SwitchHandler) finalize() error {
 	return nil
 }
 
+// start starts the switch of MAO-WFS.
+// This is the internal method.
 func (h *SwitchHandler) start() error {
 	if err := h.enableOutput(); err != nil {
 		return err
@@ -114,6 +126,8 @@ func (h *SwitchHandler) start() error {
 	return nil
 }
 
+// halt halts the switch of MAO-WFS.
+// This is the internal method.
 func (h *SwitchHandler) halt() error {
 	if err := h.disableOutput(); err != nil {
 		return err
@@ -121,6 +135,7 @@ func (h *SwitchHandler) halt() error {
 	return nil
 }
 
+// enableDigPatt enable the digital pattern output.
 func (h *SwitchHandler) enableDigPatt() error {
 	msg := "DIG:PATT ON\n"
 	if err := h.Write(msg); err != nil {

--- a/adapters/gateway/device/switch.go
+++ b/adapters/gateway/device/switch.go
@@ -21,7 +21,7 @@ func NewSwitchHandler(clt Client) *SwitchHandler {
 // Initialize initializes the switch of MAO-WFS.
 // This is the external method.
 func (h *SwitchHandler) Initialize(swOrder domain.SwitchOrder) error {
-	if err := h.enableDigPatt(); err != nil {
+	if err := h.initialize(swOrder); err != nil {
 		return xerrors.Errorf("error in Initialize(): %w", err)
 	}
 	return nil
@@ -50,6 +50,15 @@ func (h *SwitchHandler) Start() error {
 func (h *SwitchHandler) Halt() error {
 	if err := h.halt(); err != nil {
 		return xerrors.Errorf("error in Start(): %w", err)
+	}
+	return nil
+}
+
+// initialize initializes the switch of MAO-WFS.
+// This is the internal method.
+func (h *SwitchHandler) initialize(swOrder domain.SwitchOrder) error {
+	if err := h.enableDigPatt(); err != nil {
+		return err
 	}
 	return nil
 }

--- a/adapters/gateway/device/switch.go
+++ b/adapters/gateway/device/switch.go
@@ -42,9 +42,6 @@ func (h *SwitchHandler) Start() error {
 	if err := h.start(); err != nil {
 		return xerrors.Errorf("error in Start(): %w", err)
 	}
-	if err := h.checkResult(); err != nil {
-		return xerrors.Errorf("error in Start(): %w", err)
-	}
 	return nil
 }
 

--- a/adapters/gateway/device/switch.go
+++ b/adapters/gateway/device/switch.go
@@ -50,12 +50,8 @@ func (h *SwitchHandler) Start() error {
 
 // Halt halts the switch of MAO-WFS.
 func (h *SwitchHandler) Halt() error {
-	msg := "OUTP OFF\n"
-	if err := h.Write(msg); err != nil {
-		return xerrors.Errorf("error in Halt(): %w", err)
-	}
-	if err := h.checkResult(); err != nil {
-		return xerrors.Errorf("error in Halt(): %w", err)
+	if err := h.halt(); err != nil {
+		return xerrors.Errorf("error in Start(): %w", err)
 	}
 	return nil
 }
@@ -93,6 +89,14 @@ func (h *SwitchHandler) clearStatus() error {
 
 func (h *SwitchHandler) start() error {
 	msg := "OUTP ON\n"
+	if err := h.Write(msg); err != nil {
+		return err
+	}
+	return h.checkResult()
+}
+
+func (h *SwitchHandler) halt() error {
+	msg := "OUTP OFF\n"
 	if err := h.Write(msg); err != nil {
 		return err
 	}

--- a/adapters/gateway/device/switch.go
+++ b/adapters/gateway/device/switch.go
@@ -89,6 +89,14 @@ func (h *SwitchHandler) enableOutput() error {
 	return h.checkResult()
 }
 
+func (h *SwitchHandler) disableOutput() error {
+	msg := "OUTP OFF\n"
+	if err := h.Write(msg); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (h *SwitchHandler) finalize() error {
 	if err := h.reset(); err != nil {
 		return err
@@ -107,11 +115,10 @@ func (h *SwitchHandler) start() error {
 }
 
 func (h *SwitchHandler) halt() error {
-	msg := "OUTP OFF\n"
-	if err := h.Write(msg); err != nil {
+	if err := h.disableOutput(); err != nil {
 		return err
 	}
-	return h.checkResult()
+	return nil
 }
 
 func (h *SwitchHandler) enableDigPatt() error {

--- a/adapters/gateway/device/switch.go
+++ b/adapters/gateway/device/switch.go
@@ -5,7 +5,7 @@ import (
 
 	"golang.org/x/xerrors"
 
-	"github.com/mao-wfs/mao-ctrl/domain"
+	"github.com/mao-wfs/mao-client/domain"
 )
 
 // SwitchHandler is the handler of the switch of MAO-WFS.

--- a/adapters/gateway/device/switch.go
+++ b/adapters/gateway/device/switch.go
@@ -39,8 +39,7 @@ func (h *SwitchHandler) Finalize() error {
 
 // Start starts the switch of MAO-WFS.
 func (h *SwitchHandler) Start() error {
-	msg := "OUTP ON\n"
-	if err := h.Write(msg); err != nil {
+	if err := h.start(); err != nil {
 		return xerrors.Errorf("error in Start(): %w", err)
 	}
 	if err := h.checkResult(); err != nil {
@@ -86,6 +85,14 @@ func (h *SwitchHandler) reset() error {
 
 func (h *SwitchHandler) clearStatus() error {
 	msg := "*CLS\n"
+	if err := h.Write(msg); err != nil {
+		return err
+	}
+	return h.checkResult()
+}
+
+func (h *SwitchHandler) start() error {
+	msg := "OUTP ON\n"
 	if err := h.Write(msg); err != nil {
 		return err
 	}

--- a/adapters/gateway/device/switch.go
+++ b/adapters/gateway/device/switch.go
@@ -28,10 +28,7 @@ func (h *SwitchHandler) Initialize(swOrder domain.SwitchOrder) error {
 
 // Finalize finalizes the switch of MAO-WFS.
 func (h *SwitchHandler) Finalize() error {
-	if err := h.reset(); err != nil {
-		return xerrors.Errorf("error in Finalize(): %w", err)
-	}
-	if err := h.clearStatus(); err != nil {
+	if err := h.finalize(); err != nil {
 		return xerrors.Errorf("error in Finalize(): %w", err)
 	}
 	return nil
@@ -82,6 +79,16 @@ func (h *SwitchHandler) clearStatus() error {
 		return err
 	}
 	return h.checkResult()
+}
+
+func (h *SwitchHandler) finalize() error {
+	if err := h.reset(); err != nil {
+		return err
+	}
+	if err := h.clearStatus(); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (h *SwitchHandler) start() error {

--- a/adapters/gateway/device/switch.go
+++ b/adapters/gateway/device/switch.go
@@ -54,6 +54,36 @@ func (h *SwitchHandler) Halt() error {
 	return nil
 }
 
+// finalize finalizes the switch of MAO-WFS.
+// This is the internal method.
+func (h *SwitchHandler) finalize() error {
+	if err := h.reset(); err != nil {
+		return err
+	}
+	if err := h.clearStatus(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// start starts the switch of MAO-WFS.
+// This is the internal method.
+func (h *SwitchHandler) start() error {
+	if err := h.enableOutput(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// halt halts the switch of MAO-WFS.
+// This is the internal method.
+func (h *SwitchHandler) halt() error {
+	if err := h.disableOutput(); err != nil {
+		return err
+	}
+	return nil
+}
+
 // checkResult checks the result of a switch operation.
 func (h *SwitchHandler) checkResult() error {
 	msg := "SYST:ERR?\n"
@@ -100,36 +130,6 @@ func (h *SwitchHandler) enableOutput() error {
 func (h *SwitchHandler) disableOutput() error {
 	msg := "OUTP OFF\n"
 	if err := h.Write(msg); err != nil {
-		return err
-	}
-	return nil
-}
-
-// finalize finalizes the switch of MAO-WFS.
-// This is the internal method.
-func (h *SwitchHandler) finalize() error {
-	if err := h.reset(); err != nil {
-		return err
-	}
-	if err := h.clearStatus(); err != nil {
-		return err
-	}
-	return nil
-}
-
-// start starts the switch of MAO-WFS.
-// This is the internal method.
-func (h *SwitchHandler) start() error {
-	if err := h.enableOutput(); err != nil {
-		return err
-	}
-	return nil
-}
-
-// halt halts the switch of MAO-WFS.
-// This is the internal method.
-func (h *SwitchHandler) halt() error {
-	if err := h.disableOutput(); err != nil {
 		return err
 	}
 	return nil

--- a/adapters/gateway/device/switch.go
+++ b/adapters/gateway/device/switch.go
@@ -81,6 +81,14 @@ func (h *SwitchHandler) clearStatus() error {
 	return h.checkResult()
 }
 
+func (h *SwitchHandler) enableOutput() error {
+	msg := "OUTP ON\n"
+	if err := h.Write(msg); err != nil {
+		return err
+	}
+	return h.checkResult()
+}
+
 func (h *SwitchHandler) finalize() error {
 	if err := h.reset(); err != nil {
 		return err
@@ -92,11 +100,10 @@ func (h *SwitchHandler) finalize() error {
 }
 
 func (h *SwitchHandler) start() error {
-	msg := "OUTP ON\n"
-	if err := h.Write(msg); err != nil {
+	if err := h.enableOutput(); err != nil {
 		return err
 	}
-	return h.checkResult()
+	return nil
 }
 
 func (h *SwitchHandler) halt() error {

--- a/adapters/gateway/device/wfs_handler.go
+++ b/adapters/gateway/device/wfs_handler.go
@@ -3,7 +3,7 @@ package device
 import (
 	"golang.org/x/xerrors"
 
-	"github.com/mao-wfs/mao-ctrl/domain"
+	"github.com/mao-wfs/mao-client/domain"
 )
 
 // WFSHandler is the handler of MAO-WFS.

--- a/external/waf/handler/wfs.go
+++ b/external/waf/handler/wfs.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/labstack/echo"
 
-	"github.com/mao-wfs/mao-ctrl/adapters/controller"
-	"github.com/mao-wfs/mao-ctrl/usecases/input"
+	"github.com/mao-wfs/mao-client/adapters/controller"
+	"github.com/mao-wfs/mao-client/usecases/input"
 )
 
 // InitializeWFS initializes MAO-WFS.

--- a/external/waf/server.go
+++ b/external/waf/server.go
@@ -7,10 +7,10 @@ import (
 	"github.com/labstack/echo"
 	"github.com/labstack/echo/middleware"
 
-	"github.com/mao-wfs/mao-ctrl/adapters/controller"
-	"github.com/mao-wfs/mao-ctrl/adapters/gateway/device"
-	"github.com/mao-wfs/mao-ctrl/external/client"
-	"github.com/mao-wfs/mao-ctrl/external/waf/handler"
+	"github.com/mao-wfs/mao-client/adapters/controller"
+	"github.com/mao-wfs/mao-client/adapters/gateway/device"
+	"github.com/mao-wfs/mao-client/external/client"
+	"github.com/mao-wfs/mao-client/external/waf/handler"
 )
 
 type Server struct {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mao-wfs/mao-ctrl
+module github.com/mao-wfs/mao-client
 
 go 1.12
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/mao-wfs/mao-ctrl
 
+go 1.12
+
 require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
 	github.com/labstack/echo v3.3.10+incompatible
@@ -7,6 +9,6 @@ require (
 	github.com/mattn/go-colorable v0.1.1 // indirect
 	github.com/mattn/go-isatty v0.0.7 // indirect
 	github.com/valyala/fasttemplate v1.0.1 // indirect
-	golang.org/x/crypto v0.0.0-20190403202508-8e1b8d32e692 // indirect
+	golang.org/x/crypto v0.0.0-20190404164418-38d8ce5564a5 // indirect
 	golang.org/x/xerrors v0.0.0-20190315151331-d61658bd2e18
 )

--- a/go.sum
+++ b/go.sum
@@ -13,10 +13,9 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.0.1 h1:tY9CJiPnMXf1ERmG2EyK7gNUd+c6RKGD0IfU8WdUSz8=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
-golang.org/x/crypto v0.0.0-20190403202508-8e1b8d32e692 h1:GRhHqDOgeDr6QDTtq9gn2O4iKvm5dsbfqD/TXb0KLX0=
-golang.org/x/crypto v0.0.0-20190403202508-8e1b8d32e692/go.mod h1:WFFai1msRO1wXaEeE5yQxYXgSfI8pQAWXbQop6sCtWE=
+golang.org/x/crypto v0.0.0-20190404164418-38d8ce5564a5 h1:bselrhR0Or1vomJZC8ZIjWtbDmn9OYFLX5Ik9alpJpE=
+golang.org/x/crypto v0.0.0-20190404164418-38d8ce5564a5/go.mod h1:WFFai1msRO1wXaEeE5yQxYXgSfI8pQAWXbQop6sCtWE=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20190403152447-81d4e9dc473e h1:nFYrTHrdrAOpShe27kaFHjsqYSEQ0KWqdWLu3xuZJts=
 golang.org/x/sys v0.0.0-20190403152447-81d4e9dc473e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/xerrors v0.0.0-20190315151331-d61658bd2e18 h1:1AGvnywFL1aB5KLRxyLseWJI6aSYPo3oF7HSpXdWQdU=
 golang.org/x/xerrors v0.0.0-20190315151331-d61658bd2e18/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/mao-wfs/mao-ctrl/external/waf"
+	"github.com/mao-wfs/mao-client/external/waf"
 )
 
 func main() {

--- a/usecases/input/wfs.go
+++ b/usecases/input/wfs.go
@@ -1,7 +1,7 @@
 package input
 
 import (
-	"github.com/mao-wfs/mao-ctrl/domain"
+	"github.com/mao-wfs/mao-client/domain"
 )
 
 // WFSInputPort is the input port for MAO-WFS.

--- a/usecases/interactor/wfs.go
+++ b/usecases/interactor/wfs.go
@@ -1,8 +1,8 @@
 package interactor
 
 import (
-	"github.com/mao-wfs/mao-ctrl/domain"
-	"github.com/mao-wfs/mao-ctrl/usecases/input"
+	"github.com/mao-wfs/mao-client/domain"
+	"github.com/mao-wfs/mao-client/usecases/input"
 )
 
 // WFSInteractor is the interactor for MAO controller.


### PR DESCRIPTION
fixes #5 

## Issues
#5 [SPRINT] Apr 4 2019 → Apr 8 2019 - Release version 1.0

## Overview
+ Why do you change it?
  + Release version 1.0
+ What is the problem?
  + Not implemented functions to operate the correlator and the switch
+ How is the problem solved by your change?
  + Becomes possible to operate the switch and the correlator


## Important changes
+ Add the following functions
  + Correlator
    + Initialize
    + Finalize
    + Start
    + Halt
  + Switch
    + Initialize
    + Finalize
    + Start
    + Halt


## Changes
+ Package name (`mao-ctrl` -> `mao-client`)
+ Add the basic functions (Initialize, Finalize, Start, Halt)
+ Refactor this code
  + Separate to the internal method and external one


## Done
- [x] Correlator
  - [x] Implement the function to initialize
  - [x] Implement the function to finalize
  - [x] Implement the function to start
  - [x] Implement the function to halt
- [x] Switch
  - [x] Implement the function to initialize
  - [x] Implement the function to finalize
  - [x] Implement the function to start
  - [x] Implement the function to halt


## To Do
Please write items what to do below::
- [ ] Correlator
  - [ ] Format of the request to initialize (sensing time, etc.)
- [ ] Switch
  - [ ] Format of the request to setup (switching order, etc.)
- [ ] Configuration of API


## Note
We should work on the following items::
- Refactor the architecture
- Change MAO-WFS's configure not to be from environment variables but from a configuration file